### PR TITLE
use rg's `-e` option to tell rg to use the next arg as the pattern

### DIFF
--- a/rg.el
+++ b/rg.el
@@ -223,7 +223,7 @@ added as a '--type-add' parameter to the rg command line."
                (rg-build-type-add-args)
                rg-command-line-flags
                rg-toggle-command-line-flags
-               (list "<R>"))))
+               (list "-e" "<R>"))))
     (when rg-show-columns
       (setq args (cons "--column" args)))
     (when type


### PR DESCRIPTION
Otherwise patterns starting with dashes are interpreted by rg as the
name of one of rg's option, most likely causing an error by rg that
the option in question is unknown.

Fixes #15.