### PR TITLE
prevent excessive backtracking in regex engine

### DIFF
--- a/rg.el
+++ b/rg.el
@@ -183,7 +183,7 @@ for special purposes.")
      (2 'rg-error-face nil t))
     ;; "filename-linenumber-" or "linenumber-" format is used for
     ;; context lines in rg
-    ("^\\(?:.+?-\\)*?[0-9]+-.*\n" (0 'rg-context-face))))
+    ("^\\(?:.+?-\\)?[0-9]+-.*\n" (0 'rg-context-face))))
 
 (defvar rg-mode-map
   (let ((map (copy-keymap grep-mode-map)))


### PR DESCRIPTION
The following font lock regex pattern leads to excessive backtracking
due to an arbitrary number of characters in the parenthesis and an
arbitrary number of parenthesis itself:

"^\\(?:.+?-\\)*?[0-9]+-.*\n"

This leads to a lot of backtracking. The time required for matching
grows exponentially with the input length (the line length in rg's
case).

Fixes #14. It might also be the cause of #12.