### PR TITLE
add rg-dwim-regexp

### DIFF
--- a/rg.el
+++ b/rg.el
@@ -1007,8 +1007,8 @@ prefix is not supplied `rg-keymap-prefix' is used."
     (message "Global key bindings for `rg' enabled with prefix: %s"
              (edmacro-format-keys prefix))))
 
-;;;###autoload
 (defun rg-run-in-project (regexp files)
+  "Search for `REGEXP' in files of type `FILES' starting at the rg-project-root."
   (let ((root (rg-project-root buffer-file-name)))
     (if root
         (rg-run regexp files root)
@@ -1029,8 +1029,7 @@ version control system."
 
 ;;;###autoload
 (defun rg-dwim-regexp (regexp)
-  "Run ripgrep in current project searching for REGEXP in files
-like the current file"
+  "Run ripgrep in current project searching for REGEXP in files like the current file."
   (interactive
    (progn
      (let* ((regexp (rg-read-pattern)))

--- a/rg.el
+++ b/rg.el
@@ -1090,27 +1090,35 @@ prefix is not supplied `rg-keymap-prefix' is used."
 
 ;;;###autoload
 (rg-define-search rg-project
-                  :dir project)
+  "Run ripgrep in current project searching for REGEXP in FILES.
+The project root will will be determined by either common project
+packages like projectile and `find-file-in-project' or the source
+version control system."
+  :dir project)
 
 ;;;###autoload
 (rg-define-search rg-dwim-project-dir
-                  :pattern point
-                  :files current
-                  :dir project)
+  "Search for thing at point in files matching the current file
+under the project root directory."
+  :pattern point
+  :files current
+  :dir project)
 
 ;;;###autoload
 (rg-define-search rg-dwim-current-dir
-                  :pattern point
-                  :files current
-                  :dir current)
+  "Search for thing at point in files matching the current file
+under the current directory."
+  :pattern point
+  :files current
+  :dir current)
 
 ;;;###autoload
 (defun rg-dwim (&optional curdir)
-  "Run ripgrep without user interaction figuring out the intention by magic(!).
-The default magic searches for thing at point in files matching
-current file under project root directory.
-With \\[universal-argument] prefix (CURDIR), search is done in current dir
-instead of project root."
+  "Run ripgrep without user interaction figuring out the
+intention by magic(!). The default magic searches for thing at
+point in files matching current file under project root
+directory. With \\[universal-argument] prefix (CURDIR), search is
+done in current dir instead of project root."
   (interactive "P")
   (if curdir (rg-dwim-current-dir)
     (rg-dwim-project-dir)))
@@ -1125,7 +1133,18 @@ instead of project root."
                   :pattern literal)
 
 ;;;###autoload
-(rg-define-search rg)
+(rg-define-search rg
+  "Run ripgrep, searching for REGEXP in FILES in directory DIR.
+The search is limited to file names matching shell pattern FILES.
+FILES may use abbreviations defined in `rg-custom-type-aliases'
+or ripgrep builtin type aliases, e.g. entering `elisp' is
+equivalent to `*.el'. REGEXP is a regexp as defined by the
+ripgrep executable. With \\[universal-argument] prefix (CONFIRM),
+you can edit the constructed shell command line before it is
+executed. Collect output in a buffer. While ripgrep runs
+asynchronously, you can use \\[next-error] (M-x `next-error'), or
+\\<grep-mode-map>\\[compile-goto-error] \ in the rg output
+buffer, to go to the lines where rg found matches.")
 
 (provide 'rg)
 

--- a/rg.el
+++ b/rg.el
@@ -1008,6 +1008,13 @@ prefix is not supplied `rg-keymap-prefix' is used."
              (edmacro-format-keys prefix))))
 
 ;;;###autoload
+(defun rg-run-in-project (regexp files)
+  (let ((root (rg-project-root buffer-file-name)))
+    (if root
+        (rg-run regexp files root)
+      (signal 'user-error '("No project root found")))))
+
+;;;###autoload
 (defun rg-project (regexp files)
   "Run ripgrep in current project searching for REGEXP in FILES.
 The project root will will be determined by either common project
@@ -1018,10 +1025,18 @@ version control system."
      (let* ((regexp (rg-read-pattern))
             (files (rg-read-files regexp)))
        (list regexp files))))
-  (let ((root (rg-project-root buffer-file-name)))
-    (if root
-        (rg-run regexp files root)
-      (signal 'user-error '("No project root found")))))
+  (rg-run-in-project regexp files))
+
+;;;###autoload
+(defun rg-dwim-regexp (regexp)
+  "Run ripgrep in current project searching for REGEXP in files
+like the current file"
+  (interactive
+   (progn
+     (let* ((regexp (rg-read-pattern)))
+       (list regexp))))
+  (let ((files (car (rg-default-alias))))
+    (rg-run-in-project regexp files)))
 
 ;;;###autoload
 (defun rg-dwim (&optional curdir)

--- a/rg.el
+++ b/rg.el
@@ -1014,9 +1014,9 @@ prefix is not supplied `rg-keymap-prefix' is used."
 (eval-when-compile
   (defun rg-set-search-defaults (args)
     "Set defaults for required search options missing from ARGS.
-If the :confirm option is missing, set it to 'never, if
-the :format option is missing, set it to 'regexp, and if
-the :query option is missing, set it to 'ask"
+If the :confirm option is missing, set it to NEVER, if
+the :format option is missing, set it to REGEXP, and if
+the :query option is missing, set it to ASK"
     (unless (plist-get args :confirm)
       (setq args (plist-put args :confirm 'never)))
 
@@ -1102,10 +1102,11 @@ the :query option is missing, set it to 'ask"
 ;;;###autoload
 (defmacro rg-define-search (name &rest args)
   "Define an rg search functions named NAME.
-ARGS is a search specification with `:query' (point or ask),
-`:format' (literal or regexp), `files' (rg or custom file alias),
-`dir' (root search directory), and `confirm' as allowable options
-specifying the behavior of the search function."
+ARGS is a search specification with :query (POINT or ASK),
+:format (LITERAL or REGEXP), :files (rg or custom file alias),
+:dir (root search directory), and :confirm (NEVER, ALWAYS, or
+PREFIX) as allowable options specifying the behavior of the
+search function."
   (declare (indent defun))
   (let* ((body (rg-search-parse-body args))
          (decls (car body))

--- a/test/rg.el-test.el
+++ b/test/rg.el-test.el
@@ -651,26 +651,6 @@ and ungrouped otherwise."
     (rg-dwim 'curdir)
     (should (equal (expand-file-name called-dir) (expand-file-name default-directory)))))
 
-(ert-deftest rg-integration/dwim-regexp-search ()
-  "Test `rg-dwim-regexp'."
-  (cl-letf ((called-pattern nil)
-            (called-files nil)
-            (called-dir nil)
-            (called-literal nil)
-            (project-dir (expand-file-name default-directory))
-            ((symbol-function #'rg-run)
-             (lambda (pattern files dir &optional literal _)
-               (setq called-pattern pattern)
-               (setq called-files files)
-               (setq called-dir dir)
-               (setq called-literal literal))))
-    (find-file "test/data/foo.el")
-    (rg-dwim-regexp "hello")
-    (should (equal called-pattern "hello"))
-    (should (equal called-files "elisp"))
-    (should (equal (expand-file-name called-dir) project-dir))
-    (should (eq called-literal nil))))
-
 (ert-deftest rg-integration/project-search ()
   "Test `rg-project'."
   (cl-letf ((called-pattern nil)

--- a/test/rg.el-test.el
+++ b/test/rg.el-test.el
@@ -651,6 +651,26 @@ and ungrouped otherwise."
     (rg-dwim 'curdir)
     (should (equal (expand-file-name called-dir) (expand-file-name default-directory)))))
 
+(ert-deftest rg-integration/dwim-regexp-search ()
+  "Test `rg-dwim-regexp'."
+  (cl-letf ((called-pattern nil)
+            (called-files nil)
+            (called-dir nil)
+            (called-literal nil)
+            (project-dir (expand-file-name default-directory))
+            ((symbol-function #'rg-run)
+             (lambda (pattern files dir &optional literal _)
+               (setq called-pattern pattern)
+               (setq called-files files)
+               (setq called-dir dir)
+               (setq called-literal literal))))
+    (find-file "test/data/foo.el")
+    (rg-dwim-regexp "hello")
+    (should (equal called-pattern "hello"))
+    (should (equal called-files "elisp"))
+    (should (equal (expand-file-name called-dir) project-dir))
+    (should (eq called-literal nil))))
+
 (ert-deftest rg-integration/project-search ()
   "Test `rg-project'."
   (cl-letf ((called-pattern nil)


### PR DESCRIPTION
Add a new function, `rg-dwim-regexp` to search for a user provided pattern using the default type alias. `rg-dwim-regexp` is like a cross between `rg-project` and `rg-dwim` in that it skips the files confirmation but still lets you enter your own pattern.