### PR TITLE
use (executable-find "rg") instead of assuming "rg" is in path

### DIFF
--- a/rg.el
+++ b/rg.el
@@ -227,7 +227,9 @@ a string describing how the process finished.")
 (defvar rg-builtin-type-aliases nil
   "Cache for 'rg --type-list'.")
 
-(defvar rg-command "rg --color always --colors match:fg:red -n"
+(defvar rg-command
+  (concat (executable-find "rg")
+	  " --color always --colors match:fg:red -n")
   "Command string for invoking rg.")
 
 (defvar rg-last-search nil
@@ -375,7 +377,8 @@ added as a '--type-add' parameter to the rg command line."
              (s-trim
               (mapconcat 'identity (split-string (cadr association) "," t ) " ")))))
    (nbutlast (split-string
-              (shell-command-to-string "rg --type-list") "\n") 1)))
+              (shell-command-to-string
+	       (concat (executable-find "rg") " --type-list")) "\n") 1)))
 
 
 (defun rg-get-type-aliases (&optional nospecial)


### PR DESCRIPTION
in some setups `rg` isn't found because it's not in the environment's `$PATH` 

this checks in *emacs'* `exec-path`