### PR TITLE
fix font-lock-face for rg-toggle-{on,off}-face

### DIFF
--- a/rg.el
+++ b/rg.el
@@ -610,7 +610,7 @@ string."
   `(:eval (let* ((on ,on)
                  (value (if on "on " "off"))
                  (face (if on 'rg-toggle-on-face 'rg-toggle-off-face)))
-            (propertize value 'font-lock-face `(bold ,face)))))
+            (propertize value 'font-lock-face `(,face)))))
 
 (defun rg-create-header-line ()
   "Create the header line if `rg-show-header' is enabled."


### PR DESCRIPTION
The faces rg-toggle-{on,off}-face were not processed properly. Apparently only the car of the list assigned to font-lock-face is being considered. 

If this is true, also some other settings for font-lock-face won't have the desired effect (i.e. the cdr of the lists get discarded, which mostly means that the 'bold' property is ignored). 