### PR TITLE
Fix typo in description for "all" file types

### DIFF
--- a/rg.el
+++ b/rg.el
@@ -294,7 +294,7 @@ excluded."
                         filename))
         (rg-get-type-aliases t)))
      ;; Default when an alias for the file can't be determined
-     '("all" . "all gn defined file types"))))
+     '("all" . "all defined file types"))))
 
 (defun rg-read-files ()
   "Read files argument for interactive rg."


### PR DESCRIPTION
There seems to be a stray "gn" in the description, from commit https://github.com/dajva/rg.el/commit/46716f21f885fba955bfed7dce3bd2759db70070