### PR TITLE
add rg-dwim-current-file to narrow rg-dwim even more.

### DIFF
--- a/rg.el
+++ b/rg.el
@@ -707,17 +707,33 @@ under the current directory."
   :files current
   :dir current)
 
+;;;###autoload (autoload 'rg-dwim-current-file "rg.el" "" t)
+(rg-define-search rg-dwim-current-file
+  "Search for thing at point in files matching the current file
+name (as a pattern) under the current directory."
+  :query point
+  :format literal
+  :files (file-name-nondirectory (buffer-file-name))
+  :dir current)
+
 ;;;###autoload
 (defun rg-dwim (&optional curdir)
   "Run ripgrep without user interaction figuring out the intention by magic(!).
-The default magic searches for thing at
-point in files matching current file under project root
-directory.  With \\[universal-argument] prefix (CURDIR), search is
-done in current dir instead of project root."
+The default magic searches for thing at point in files matching
+current file under project root directory.
+
+With \\[universal-argument] prefix (CURDIR), search is done in
+current dir instead of project root.
+
+With repeated \\[universal-argument] prefix, search is done in
+the current dir and using the current variable `buffer-file-name'
+as a pattern.  Subdirectories are still searched, so different
+files with the same name pattern still will be searched."
   (interactive "P")
-  (if curdir
-      (rg-dwim-current-dir)
-    (rg-dwim-project-dir)))
+  (cond
+   ((eq  4 (and (consp curdir) (car curdir))) (rg-dwim-current-dir))
+   ((eq 16 (and (consp curdir) (car curdir))) (rg-dwim-current-file))
+   (t     (rg-dwim-project-dir))))
 
 ;;;###autoload (autoload 'rg-literal "rg.el" "" t)
 (rg-define-search rg-literal

--- a/test/rg.el-test.el
+++ b/test/rg.el-test.el
@@ -840,8 +840,10 @@ and ungrouped otherwise."
     (should (equal called-files "elisp"))
     (should (equal (expand-file-name called-dir) project-dir))
     (should-not (eq called-literal nil))
-    (rg-dwim 'curdir)
-    (should (equal (expand-file-name called-dir) (expand-file-name default-directory)))))
+    (rg-dwim '(4))
+    (should (equal (expand-file-name called-dir) (expand-file-name default-directory)))
+    (rg-dwim '(16))
+    (should (equal called-files "foo.el"))))
 
 (ert-deftest rg-integration/project-search ()
   "Test `rg-project'."


### PR DESCRIPTION
Following the trend of c-u meaning "more focused", this commit
implements c-u c-u rg-dwim as even narrower search, searching just in
the current file.

Still have to figure out how to run the tests correctly in my box.