### PR TITLE
Allow to customize results buffer name

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ It is also possible to set the prefix when invoking `rg-enable-default-bindings`
 | `<prefix> S` | `rg-save-search-as-name` |
 | `<prefix> t` | `rg-literal` |
 
-### The \*rg\* buffer
+### The results buffer
 The `rg` results buffer has bindings for modification of the last
 search for quick reruns with refined parameters.
 
@@ -199,6 +199,18 @@ for the bindings to be enabled.
 Controls if the search info header is shown in the result
 buffer. This is enabled by default but can be disabled by setting this
 variable to `nil`.
+
+### `rg-buffer-name`
+Controls the name of the results buffer. It may be string or function. One usefull case of using it is to have separate result buffers per project.
+One can set this variable in `dir-locals` file or set it to function. E.g. this function will set results buffer name based on `project-current`:
+
+``` emacs-lisp
+(defun my/rg-buffer-name ()
+  (let ((p (project-current)))
+    (if p
+        (format "rg %s" (abbreviate-file-name (cdr p)))
+      "rg"))))
+```
 
 ### Position numbers alignment
 When operating `rg.el` in grouped output mode (`rg-group-result` is

--- a/README.md
+++ b/README.md
@@ -201,8 +201,10 @@ buffer. This is enabled by default but can be disabled by setting this
 variable to `nil`.
 
 ### `rg-buffer-name`
-Controls the name of the results buffer. It may be string or function. One usefull case of using it is to have separate result buffers per project.
-One can set this variable in `dir-locals` file or set it to function. E.g. this function will set results buffer name based on `project-current`:
+Controls the name of the results buffer. It may be string or function.
+One usefull case of using it is to have separate result buffers per project.
+One can set this variable in `dir-locals` file or set it to function.
+E.g. this function will set results buffer name based on `project-current`:
 
 ``` emacs-lisp
 (defun my/rg-buffer-name ()

--- a/rg-result.el
+++ b/rg-result.el
@@ -441,9 +441,10 @@ Commands:
                            (rg-search-full-command rg-cur-search))))
 
 (defun rg-mode-init (search)
-  "Initiate rg-mode with SEARCH in current buffer."
+  "Initiate `rg-mode' with SEARCH in current buffer."
   (unless (eq major-mode 'rg-mode)
     (error "Function rg-mode-init called in non rg mode buffer"))
+  (hack-dir-local-variables-non-file-buffer)
   (setq rg-cur-search search)
   (rg-history-push (rg-search-copy rg-cur-search)
                    rg-search-history)
@@ -453,6 +454,7 @@ Commands:
   "Rerun the current search."
   (interactive)
   (recompile)
+  (hack-dir-local-variables-non-file-buffer)
   (rg-maybe-show-header))
 
 (defun rg-rerun (&optional no-history)

--- a/rg-result.el
+++ b/rg-result.el
@@ -178,6 +178,9 @@ Becomes buffer local in `rg-mode' buffers.")
 (defvar-local rg-hit-count 0
   "Stores number of hits in a search.")
 
+(defvar-local rg-recompile nil
+  "Is `recompile' in progress or `compile-start'.")
+
 (defconst rg-mode-font-lock-keywords
   '(;; Command output lines.
     (": \\(.+\\): \\(?:Permission denied\\|No such \\(?:file or directory\\|device or address\\)\\)$"
@@ -453,7 +456,8 @@ Commands:
 (defun rg-recompile ()
   "Rerun the current search."
   (interactive)
-  (recompile)
+  (let ((rg-recompile t))
+    (recompile))
   (hack-dir-local-variables-non-file-buffer)
   (rg-maybe-show-header))
 

--- a/rg.el
+++ b/rg.el
@@ -223,10 +223,9 @@ Raises an error if it can not be found."
       (funcall rg-buffer-name)
     rg-buffer-name))
 
-(defun rg-buffer-name (&optional mode_name)
+(defun rg-buffer-name (&optional _mode_name)
   "Return search results buffer name.
 MODE_NAME is needed to pass this function to `compilation-start'."
-  (ignore mode_name)
   (format "*%s*" (rg--buffer-name)))
 
 (defun rg-build-type-add-args ()

--- a/rg.el
+++ b/rg.el
@@ -218,7 +218,7 @@ Raises an error if it can not be found."
           " --color always --colors match:fg:red -n"))
 
 (defun rg--buffer-name ()
-  "Wrapper for variable `rg-buffer-name'. Return string or call function."
+  "Wrapper for variable `rg-buffer-name'.  Return string or call function."
   (if (functionp rg-buffer-name)
       (funcall rg-buffer-name)
     rg-buffer-name))

--- a/rg.el
+++ b/rg.el
@@ -223,10 +223,10 @@ Raises an error if it can not be found."
       (funcall rg-buffer-name)
     rg-buffer-name))
 
-(defun rg-buffer-name (&optional mode_name)
+(defun rg-buffer-name (&optional name-of-mode)
   "Return search results buffer name.
-MODE_NAME is needed to pass this function to `compilation-start'."
-  (ignore mode_name)
+NAME-OF-MODE is needed to pass this function to `compilation-start'."
+  (ignore name-of-mode)
   (if rg-recompile
       (buffer-name)
     (format "*%s*" (rg--buffer-name))))

--- a/rg.el
+++ b/rg.el
@@ -477,9 +477,9 @@ optional DEFAULT parameter is non nil the flag will be enabled by default."
          (rg-rerun-toggle-flag ,flagvalue)))))
 
 (defun rg-save-search-as-name (newname)
-  "Save the search result in current *rg* result buffer.
-The result buffer will be renamed to *rg NEWNAME*.  New searches will use the
-standard *rg* buffer unless the search is done from a saved buffer in
+  "Save the search result in current result buffer.
+NEWNAME will be added to the result buffer name.  New searches will use the
+standard buffer unless the search is done from a saved buffer in
 which case the saved buffer will be reused."
   (interactive "sSave search as name: ")
   (let ((buffer (rg-get-rename-target)))
@@ -487,22 +487,22 @@ which case the saved buffer will be reused."
       (rename-buffer (format "*%s %s*" (rg--buffer-name) newname)))))
 
 (defun rg-save-search ()
-  "Save the search result in current *rg* result buffer.
+  "Save the search result in current result buffer.
 The result buffer will be renamed by the `rename-uniquify' function.
 To choose a custom name, use `rg-save-search-as-name' instead.  New
-searches will use the standard *rg* buffer unless the search is done
-from a saved buffer in which case the saved buffer will be reused."
+searches will use the standard buffer unless the search is done from
+a saved buffer in which case the saved buffer will be reused."
   (interactive)
   (let ((buffer (rg-get-rename-target)))
     (with-current-buffer buffer
       (rename-uniquely)
-      ;; If the new buffer name became '*rg*', just rename again to make
-      ;; sure the result is saved.
+      ;; If the new buffer name became default result buffer name, just rename
+      ;; again to make sure the result is saved.
       (when (equal (buffer-name) (rg-buffer-name))
         (rename-uniquely)))))
 
 (defun rg-kill-saved-searches ()
-  "Kill all saved rg buffers.  The default *rg* buffer will be kept."
+  "Kill all saved rg buffers.  The default result buffer will be kept."
   (interactive)
   (when (y-or-n-p "Confirm kill all saved rg searches? ")
     (dolist (buf (buffer-list))

--- a/rg.el
+++ b/rg.el
@@ -217,13 +217,17 @@ Raises an error if it can not be found."
   (concat (rg-executable)
           " --color always --colors match:fg:red -n"))
 
+(defun rg--buffer-name ()
+  "Wrapper for variable `rg-buffer-name'. Return string or call function."
+  (if (functionp rg-buffer-name)
+      (funcall rg-buffer-name)
+    rg-buffer-name))
+
 (defun rg-buffer-name (&optional mode_name)
   "Return search results buffer name.
 MODE_NAME is needed to pass this function to `compilation-start'."
   (ignore mode_name)
-  (format "*%s*" (if (functionp rg-buffer-name)
-                    (funcall rg-buffer-name)
-                  rg-buffer-name)))
+  (format "*%s*" (rg--buffer-name)))
 
 (defun rg-build-type-add-args ()
   "Build a list of --type-add: 'foo:*.foo' flags for each type in `rg-custom-type-aliases'."
@@ -479,7 +483,7 @@ which case the saved buffer will be reused."
   (interactive "sSave search as name: ")
   (let ((buffer (rg-get-rename-target)))
     (with-current-buffer buffer
-      (rename-buffer (concat "*rg " newname "*")))))
+      (rename-buffer (format "*%s %s*" (rg--buffer-name) newname)))))
 
 (defun rg-save-search ()
   "Save the search result in current *rg* result buffer.

--- a/rg.el
+++ b/rg.el
@@ -225,7 +225,7 @@ Raises an error if it can not be found."
 
 (defun rg-buffer-name (&optional _mode_name)
   "Return search results buffer name.
-MODE_NAME is needed to pass this function to `compilation-start'."
+_MODE_NAME is needed to pass this function to `compilation-start'."
   (format "*%s*" (rg--buffer-name)))
 
 (defun rg-build-type-add-args ()

--- a/rg.el
+++ b/rg.el
@@ -223,9 +223,10 @@ Raises an error if it can not be found."
       (funcall rg-buffer-name)
     rg-buffer-name))
 
-(defun rg-buffer-name (&optional _mode_name)
+(defun rg-buffer-name (&optional mode_name)
   "Return search results buffer name.
-_MODE_NAME is needed to pass this function to `compilation-start'."
+MODE_NAME is needed to pass this function to `compilation-start'."
+  (ignore mode_name)
   (if rg-recompile
       (buffer-name)
     (format "*%s*" (rg--buffer-name))))

--- a/rg.el
+++ b/rg.el
@@ -226,7 +226,9 @@ Raises an error if it can not be found."
 (defun rg-buffer-name (&optional _mode_name)
   "Return search results buffer name.
 _MODE_NAME is needed to pass this function to `compilation-start'."
-  (format "*%s*" (rg--buffer-name)))
+  (if rg-recompile
+      (buffer-name)
+    (format "*%s*" (rg--buffer-name))))
 
 (defun rg-build-type-add-args ()
   "Build a list of --type-add: 'foo:*.foo' flags for each type in `rg-custom-type-aliases'."

--- a/rg.el
+++ b/rg.el
@@ -220,6 +220,7 @@ Raises an error if it can not be found."
 (defun rg-buffer-name (&optional mode_name)
   "Return search results buffer name.
 MODE_NAME is needed to pass this function to `compilation-start'."
+  (ignore mode_name)
   (format "*%s*" (if (functionp rg-buffer-name)
                     (funcall rg-buffer-name)
                   rg-buffer-name)))

--- a/rg.el
+++ b/rg.el
@@ -216,9 +216,9 @@ Raises an error if it can not be found."
   (concat (rg-executable)
           " --color always --colors match:fg:red -n"))
 
-(defun rg-default-buffer-name-function (&rest _mode_name)
-  "Return search results buffer name."
-  "*rg*")
+(defun rg-default-buffer-name-function (mode_name)
+  "Return search results buffer name for MODE_NAME."
+  (format "*%s*" mode_name))
 
 (defun rg-build-type-add-args ()
   "Build a list of --type-add: 'foo:*.foo' flags for each type in `rg-custom-type-aliases'."

--- a/test/rg-history.el-test.el
+++ b/test/rg-history.el-test.el
@@ -75,7 +75,7 @@ search after moving in history."
                    "bar" "all" (concat default-directory "test/data"))
   (rg-run-and-wait #'rg-run
                    "baz" "all" (concat default-directory "test/data"))
-  (with-current-buffer "*rg*"
+  (with-current-buffer (rg-buffer-name)
      (rg-run-and-wait #'rg-back-history)
      (should (equal (rg-search-pattern rg-cur-search) "bar"))
      (rg-run-and-wait #'rg-back-history)

--- a/test/rg.el-test.el
+++ b/test/rg.el-test.el
@@ -765,7 +765,7 @@ and ungrouped otherwise."
   "Verify exit messages."
   :tags '(need-rg)
   (rg-run "foo" "*.baz" (concat default-directory "test/data"))
-  (with-current-buffer "*rg*"
+  (with-current-buffer (rg-buffer-name)
     (rg-wait-for-search-result)
     (s-matches-p "no matches found" (buffer-substring-no-properties (point-min) (point-max))))
   (rg-run "hello" "*.baz" (concat default-directory "test/data"))

--- a/test/rg.el-test.el
+++ b/test/rg.el-test.el
@@ -75,6 +75,27 @@
     (should (s-matches? (rg-regexp-anywhere-but-last "--foo --bar")
                         (rg-build-command "" "" nil nil)))))
 
+(ert-deftest rg-unit-test/rg-buffer-name-string ()
+  "Test that function `rg-buffer-name' will return correct buffer
+name if varible `rg-buffer-name' is string."
+  (let ((rg-buffer-name "rg results"))
+    (should (string= "*rg results*" (rg-buffer-name)))))
+
+(ert-deftest rg-unit-test/rg-buffer-name-function ()
+  "Test that function `rg-buffer-name' will return correct buffer
+name if varible `rg-buffer-name' is function."
+  (let ((rg-buffer-name (lambda () "" "rg results")))
+    (should (string= "*rg results*" (rg-buffer-name)))))
+
+(ert-deftest rg-unit-test/save-search-as-name ()
+  "Verify exit messages."
+  :tags '(need-rg)
+  (let ((rg-buffer-name "rg results"))
+    (rg-run "foo" "*.baz" (concat default-directory "test/data"))
+    (with-current-buffer (rg-buffer-name)
+      (rg-save-search-as-name "bar")
+      (should (string= "*rg results bar*" (buffer-name))))))
+
 (ert-deftest rg-unit-test/toggle-command-flag ()
   "Test `rg-list-toggle'."
   (let ((testflag "--foo")

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -49,7 +49,7 @@
 (defun rg-run-and-wait (fn &rest args)
   "Run FN  with ARGS and then wait for search to be done."
   (apply fn args)
-  (with-current-buffer "*rg*"
+  (with-current-buffer (rg-buffer-name)
     (rg-wait-for-search-result)))
 
 (defun rg-wait-for-search-result ()
@@ -76,10 +76,10 @@ repository."
 (defmacro rg-with-current-result (&rest body)
   "Evaluate BODY in current result buffer when search has finished."
   (declare (indent 0) (debug t))
-  `(with-current-buffer "*rg*"
+  `(with-current-buffer (rg-buffer-name)
      (rg-wait-for-search-result)
      (let ((result (progn ,@body)))
-       (kill-buffer "*rg*")
+       (kill-buffer)
        result)))
 
 (defmacro rg-with-temp-global-keymap (&rest body)


### PR DESCRIPTION
If one work in two different projects simultaneously it is very handy to have search results separated by project.

This patch allows to separate search results by project like this:

```elisp
(defun my/rg-buffer-name (&rest _mode_name)
  (let ((p (project-current)))
    (if p
        (format "*rg - %s*" (abbreviate-file-name (cdr p)))
      "*rg*")))

(custom-set-variables
  '(rg-buffer-name-function 'myd/rg-buffer-name))
```