### PR TITLE
Load dir-locals for search dir before compilation start

### DIFF
--- a/rg.el
+++ b/rg.el
@@ -416,10 +416,13 @@ executing.  FLAGS is additional command line flags to use in the search."
         ;; If user changed command we can't know the parts of the
         ;; search and needs to disable result buffer modifications.
         (setf (rg-search-full-command search) command))
-      ;; Setting process-setup-function makes exit-message-function work
-      ;; even when async processes aren't supported.
-      (with-current-buffer (compilation-start command 'rg-mode #'rg-buffer-name)
-        (rg-mode-init search)))
+      ;; Temp buffer used to hack dir-locals variables based on search directory
+      (with-temp-buffer
+        (hack-dir-local-variables-non-file-buffer)
+        ;; Setting process-setup-function makes exit-message-function work
+        ;; even when async processes aren't supported.
+        (with-current-buffer (compilation-start command 'rg-mode #'rg-buffer-name)
+          (rg-mode-init search))))
     (if (eq next-error-last-buffer (current-buffer))
         (setq default-directory dir))))
 

--- a/rg.el
+++ b/rg.el
@@ -416,7 +416,14 @@ executing.  FLAGS is additional command line flags to use in the search."
         ;; If user changed command we can't know the parts of the
         ;; search and needs to disable result buffer modifications.
         (setf (rg-search-full-command search) command))
-      ;; Temp buffer used to hack dir-locals variables based on search directory
+      ;; Since `rg-buffer-name' can be changed through dir-locals file we
+      ;; need to apply variables from dir-locals that resides in search dir.
+      ;; This way the results buffer will receive correct name on `compilation-start'.
+      ;; `hack-dir-local-variables' is searching dir-locals file in
+      ;; `buffer-file-name' or `default-directory' directory.
+      ;; Temporary buffer must be created here to make sure that dir-locals
+      ;; file is loaded from `default-directory' defined above and
+      ;; not from `buffer-file-name' in case search is started from file buffer.
       (with-temp-buffer
         (hack-dir-local-variables-non-file-buffer)
         ;; Setting process-setup-function makes exit-message-function work

--- a/test/data/dirlocals/.dir-locals.el
+++ b/test/data/dirlocals/.dir-locals.el
@@ -1,0 +1,1 @@
+((nil . ((rg-buffer-name . "from dir locals"))))

--- a/test/rg.el-test.el
+++ b/test/rg.el-test.el
@@ -89,6 +89,10 @@ name if varible `rg-buffer-name' is function."
 
 (ert-deftest rg-unit-test/rg-buffer-name-dirlocals ()
   "Test that `rg-buffer-name' is set from dir-locals.el."
+  ;; This test covers two cases:
+  ;; - that dir-locals from search dir is applied at all
+  ;; - that dir-locals from search dir is applied if search is
+  ;;   started from file buffers
   :tags '(need-rg)
   (let ((safe-local-variable-values '((rg-buffer-name . "from dir locals"))))
     (find-file (concat default-directory "test/data/foo.baz"))

--- a/test/rg.el-test.el
+++ b/test/rg.el-test.el
@@ -90,12 +90,10 @@ name if varible `rg-buffer-name' is function."
 (ert-deftest rg-unit-test/rg-buffer-name-dirlocals ()
   "Test that `rg-buffer-name' is set from dir-locals.el."
   :tags '(need-rg)
-  (custom-set-variables
-   '(safe-local-variable-values
-     '((rg-buffer-name . "from dir locals"))))
-  (find-file (concat default-directory "test/data/foo.baz"))
-  (rg-run "foo" "*.baz" (concat default-directory "dirlocals"))
-  (should (get-buffer "*from dir locals*")))
+  (let ((safe-local-variable-values '((rg-buffer-name . "from dir locals"))))
+    (find-file (concat default-directory "test/data/foo.baz"))
+    (rg-run "foo" "*.baz" (concat default-directory "dirlocals"))
+    (should (get-buffer "*from dir locals*"))))
 
 (ert-deftest rg-unit-test/save-search-as-name ()
   "Verify exit messages."

--- a/test/rg.el-test.el
+++ b/test/rg.el-test.el
@@ -29,9 +29,6 @@
 
 ;; Unit tests
 
-(when (> emacs-major-version 26)
-  (defalias 'ert--print-backtrace 'backtrace-to-string))
-
 (ert-deftest rg-unit-test/case-expand-template ()
   "Test that `rg-apply-case-flag' handles case settings correctly."
   (let (rg-toggle-command-line-flags)

--- a/test/rg.el-test.el
+++ b/test/rg.el-test.el
@@ -29,6 +29,9 @@
 
 ;; Unit tests
 
+(when (> emacs-major-version 26)
+  (defalias 'ert--print-backtrace 'backtrace-to-string))
+
 (ert-deftest rg-unit-test/case-expand-template ()
   "Test that `rg-apply-case-flag' handles case settings correctly."
   (let (rg-toggle-command-line-flags)
@@ -86,6 +89,16 @@ name if varible `rg-buffer-name' is string."
 name if varible `rg-buffer-name' is function."
   (let ((rg-buffer-name (lambda () "" "rg results")))
     (should (string= "*rg results*" (rg-buffer-name)))))
+
+(ert-deftest rg-unit-test/rg-buffer-name-dirlocals ()
+  "Test that `rg-buffer-name' is set from dir-locals.el."
+  :tags '(need-rg)
+  (custom-set-variables
+   '(safe-local-variable-values
+     '((rg-buffer-name . "from dir locals"))))
+  (find-file (concat default-directory "test/data/foo.baz"))
+  (rg-run "foo" "*.baz" (concat default-directory "dirlocals"))
+  (should (get-buffer "*from dir locals*")))
 
 (ert-deftest rg-unit-test/save-search-as-name ()
   "Verify exit messages."


### PR DESCRIPTION
Running search with `rg` or `rg-literal` must load variables from `dir-locals` file for search directory to initialize `rg-buffer-name` before `compilation-start`