### PR TITLE
Handle case where project.el detects no project

### DIFF
--- a/rg.el
+++ b/rg.el
@@ -338,7 +338,9 @@ If LITERAL is non nil prompt for literal string.  DEFAULT is the default pattern
    (when (and (require 'project nil t)
               (fboundp 'project-current)
               (fboundp 'project-roots))
-     (car (project-roots (project-current))))
+     (let ((project (project-current)))
+       (when project
+         (car (project-roots project)))))
    (condition-case nil
        (let* ((file (or file default-directory))
               (backend (vc-responsible-backend file)))


### PR DESCRIPTION
Previously if Projectile and find-file-in-project both failed, then rg.el was assuming that (project-current) would return a valid project. But if project.el can't find a project, then it'll return nil, which will cause an error when passed to `project-roots`.