### PR TITLE
Allow running rg from Dired on root directory

### DIFF
--- a/rg.el
+++ b/rg.el
@@ -341,17 +341,10 @@ If LITERAL is non nil prompt for literal string.  DEFAULT is the default pattern
      (let ((project (project-current)))
        (when project
          (car (project-roots project)))))
-   (condition-case nil
-       (let* ((file (or file default-directory))
-              (backend (vc-responsible-backend file)))
-         (vc-call-backend backend 'root file))
-     (error (if file
-                (or (file-name-directory file)
-                    ;; in case FILE is a relative path with no
-                    ;; directory component
-                    default-directory)
-              ;; in case we're not visiting any file
-              default-directory)))))
+   (let ((file (expand-file-name (or file default-directory))))
+     (condition-case nil
+         (vc-call-backend (vc-responsible-backend file) 'root file)
+       (error (file-name-directory file))))))
 
 (defun rg-run (pattern files dir &optional literal confirm flags)
   "Execute rg command with supplied PATTERN, FILES and DIR.

--- a/rg.el
+++ b/rg.el
@@ -345,8 +345,13 @@ If LITERAL is non nil prompt for literal string.  DEFAULT is the default pattern
        (let* ((file (or file default-directory))
               (backend (vc-responsible-backend file)))
          (vc-call-backend backend 'root file))
-     (error (progn
-              (file-name-directory file))))))
+     (error (if file
+                (or (file-name-directory file)
+                    ;; in case FILE is a relative path with no
+                    ;; directory component
+                    default-directory)
+              ;; in case we're not visiting any file
+              default-directory)))))
 
 (defun rg-run (pattern files dir &optional literal confirm flags)
   "Execute rg command with supplied PATTERN, FILES and DIR.


### PR DESCRIPTION
Previously if you opened a Dired buffer to the root directory of your filesystem and attempted to use rg, rg-project-root would get a nil value for FILE. All of the backends would fail to provide a project root, so rg-project-root would fall back on asking for the directory that contains FILE. Unfortunately, in this case FILE is unset. The problem is solved by handling the cases where FILE is nil (or doesn't have a directory component), and defaulting to default-directory.