### PR TITLE
extend rg-define-search :format to accept lisp form

### DIFF
--- a/docs/configuration.org
+++ b/docs/configuration.org
@@ -464,7 +464,9 @@
     prompt the user for a string.  Any form that evaluates to a string
     is allowed. Default is =ask=.
   - *:format* - Specifies if =:query= is interpreted literally
-    (=literal=) or as a regexp (=regexp=). Default is =regexp=.
+    (=literal=) or as a regexp (=regexp=). If it is a form, eg.
+    =(not current-prefix-arg)=, and is non-nil the =:query= is interpreted
+    literally, otherwise as a regexp. Default is =regexp=.
   - *:files* - Form that evaluates to a file alias or custom file
     glob. =current= means extract alias from current buffer file name,
     =ask= will prompt the user. Default is =ask=.


### PR DESCRIPTION
Extends `:format` argument to allow evaluation of lisp form,
but still respects `literal` and `regexp` symbols.  Thus, a search function
that could replace projectile's ripgrep function could look like (search literal with no
prefix, regexp with a prefix) -- closes #74 

```
;;;###autoload(autoload 'my-projectile-rg "my-rg")
(rg-define-search my-projectile-rg
  :query (or (thing-at-point 'symbol) (read-from-minibuffer "Search: "))
  :dir project
  :format (not current-prefix-arg)
  :files (concat
          (mapconcat
           #'identity
           (--map (concat "--glob !" it)
                  (append projectile-globally-ignored-files
                          projectile-globally-ignored-directories)) " "))
  :flags '("--type all"))
```