### PR TITLE
Quote search pattern

### DIFF
--- a/rg.el
+++ b/rg.el
@@ -242,7 +242,7 @@ are command line flags to use for the search."
 
     (grep-expand-template
      (mapconcat 'identity (cons (rg-executable) (delete-dups command-line)) " ")
-     pattern
+     (shell-quote-argument pattern)
      (if (rg-is-custom-file-pattern files) "custom" files))))
 
 (defun rg-invoke-rg-type-list ()


### PR DESCRIPTION
To prevent shell expansion.

Example that fails:
  rg -n --column --engine auto -i --heading --no-config --type=c -e rcu_read_unlock\\(
  regex could not be compiled with either the default regex engine or with PCRE2.

  default regex engine error:
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  regex parse error:
      rcu_read_unlock(
                     ^
  error: unclosed group
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  PCRE2 regex engine error:
  PCRE2: error compiling pattern at offset 16: missing closing parenthesis

Example that works:
  rg -n --column --engine auto -i --heading --no-config --type=c -e 'rcu_read_unlock\\('

Signed-off-by: Alexander Egorenkov <egorenar-dev@posteo.net>