### PR TITLE
Make filenames clickable in result buffer in grouped output mode

### DIFF
--- a/rg-result.el
+++ b/rg-result.el
@@ -500,12 +500,19 @@ This function is called from `compilation-filter-hook'."
           (regexp-quote (or (and rg-align-position-numbers
                                  rg-align-position-content-separator) ":"))))
 
+(defconst rg-file-name-pattern-group
+  "^File: \\(.*\\)$"
+  "A regexp pattern to match file name in grouped output mode")
+
 (defun rg-match-grouped-filename ()
   "Match filename backwards when a line/column match is found in grouped output mode."
   (save-match-data
     (save-excursion
-      (when (re-search-backward "^File: \\(.*\\)$" (point-min) t)
+      (when (re-search-backward rg-file-name-pattern-group (point-min) t)
         (list (match-string 1))))))
+
+(defun first-available-line-number ()
+  1)
 
 (defun rg-set-compilation-error-regexps ()
   "Set the compilation mode regexps for errors for rg-mode buffers."
@@ -513,12 +520,14 @@ This function is called from `compilation-filter-hook'."
        '(rg-group-with-column
          rg-nogroup-with-column
          rg-group-no-column
-         rg-nogroup-no-column))
+         rg-nogroup-no-column
+         rg-group-file-itself))
   (set (make-local-variable 'compilation-error-regexp-alist-alist)
        (list (cons 'rg-nogroup-no-column (list rg-file-line-pattern-nogroup 1 2))
              (cons 'rg-nogroup-with-column (list rg-file-line-column-pattern-nogroup 1 2 3))
              (cons 'rg-group-with-column (list (rg-file-line-column-pattern-group) 'rg-match-grouped-filename 1 2))
-             (cons 'rg-group-no-column (list (rg-file-line-pattern-group) 'rg-match-grouped-filename 1)))))
+             (cons 'rg-group-no-column (list (rg-file-line-pattern-group) 'rg-match-grouped-filename 1))
+             (cons 'rg-group-file-itself (list rg-file-name-pattern-group 1 'first-available-line-number)))))
 
 (define-compilation-mode rg-mode "rg"
   "Major mode for `rg' search results.


### PR DESCRIPTION
**Problem**

Almost every time I browse search results in grouped mode, I instinctively try to click the filename, just to see what that file is where there are so many occurrences. It's quite counter-intuitive while the filename itself isn't clickable.

**Solution**

In grouped output mode, list filename output lines as compilation errors too and direct the clicks to the beginning of the file.

**Comments/Questions**

Before polishing this PR and/or working on it further, I must ask:  does this amendment even have a chance to be accepted?