### PR TITLE
Add toggle word to result buffer

### DIFF
--- a/docs/usage.org
+++ b/docs/usage.org
@@ -502,6 +502,14 @@
 
     :COMMAND:
     #+BEGIN_SRC elisp :results value raw :exports results
+    (rg-command-info #'rg-rerun-toggle-word 'rg-mode-map)
+    #+END_SRC
+    Toggle word search. The state of the flag is shown
+    in the *[word]* header field.
+    :END:
+
+    :COMMAND:
+    #+BEGIN_SRC elisp :results value raw :exports results
     (rg-command-info #'rg-rerun-toggle-ignore 'rg-mode-map)
     #+END_SRC
     Toggle if ignore files are respected. The state of the flag is shown

--- a/rg-header.el
+++ b/rg-header.el
@@ -133,6 +133,12 @@ If FULL-COMMAND specifies if the full command line search was done."
               (rg-header-render-toggle
                `(not (member "--no-ignore" (rg-search-flags ,search)))))
              itemspace
+             (rg-header-render-label "word")
+             (rg-header-mouse-action
+              'rg-rerun-toggle-word "Toggle word"
+              (rg-header-render-toggle
+               `(member "--word-regexp" (rg-search-flags ,search))))
+             itemspace
              (rg-header-render-label "hits")
                '(:eval (format "%d" rg-hit-count)))))))
 

--- a/rg-result.el
+++ b/rg-result.el
@@ -282,6 +282,7 @@ Becomes buffer local in `rg-mode' buffers.")
     (define-key map "s" 'rg-save-search)
     (define-key map "S" 'rg-save-search-as-name)
     (define-key map "t" 'rg-rerun-change-literal)
+    (define-key map "w" 'rg-rerun-toggle-word)
     (define-key map "e" 'wgrep-change-to-wgrep-mode)
     (define-key map "\M-N" 'rg-next-file)
     (define-key map "\M-P" 'rg-prev-file)
@@ -692,6 +693,11 @@ otherwise a regexp search."
   "Rerun last search but prompt for new literal."
   (interactive)
   (rg-rerun-change-search-string t))
+
+(defun rg-rerun-toggle-word ()
+  "Rerun last search with toggled '--word-regexp' flag."
+  (interactive)
+  (rg-rerun-toggle-flag "--word-regexp"))
 
 (defun rg-rerun-change-files()
   "Rerun last search but prompt for new files."


### PR DESCRIPTION
Hello,

It would be nice to have `word` search toggle to match other editors.

Emacs:
<img width="606" alt="image" src="https://user-images.githubusercontent.com/979515/183071993-b30e425f-1124-4d87-9e48-e2b3745367d6.png">

VSCode
<img width="422" alt="image" src="https://user-images.githubusercontent.com/979515/183071201-0ea93c1a-eef5-4a3d-87e8-5bdac5e02597.png">

Webstorm
<img width="574" alt="image" src="https://user-images.githubusercontent.com/979515/183071557-7f3ab192-63ac-4bbe-8a60-46de0296c406.png">

