### PR TITLE
Fix the issue where rg.el couldn't search Unicode characters.

### DIFF
--- a/rg.el
+++ b/rg.el
@@ -144,6 +144,17 @@ Disabling this setting can break functionality of this package."
   :type 'boolean
   :group 'rg)
 
+(defcustom rg-w32-unicode nil
+  "Enable the workaround for NTEmacs subprocess not supporting Unicode arguments."
+  :type 'boolean
+  :group 'rg)
+
+(defcustom rg-w32-ripgrep-proxy
+  (expand-file-name "rg-w32-ripgrep-proxy.bat" user-emacs-directory)
+  "An automatically generated temporary batch file used to proxy ripgrep Unicode arguments."
+  :type 'string
+  :group 'rg)
+
 ;;;###autoload
 (defvar rg-command-line-flags-function 'identity
   "Function to modify command line flags of a search.
@@ -297,10 +308,18 @@ are command line flags to use for the search."
           (when (member system-type '(darwin windows-nt))
             (list ".")))))
 
-    (grep-expand-template
-     (mapconcat 'identity (cons (rg-executable) (delete-dups command-line)) " ")
-     pattern
-     (if (rg-is-custom-file-pattern files) "custom" files))))
+    (let ((command (grep-expand-template
+                    (mapconcat 'identity (cons (rg-executable) (delete-dups command-line)) " ")
+                    pattern
+                    (if (rg-is-custom-file-pattern files) "custom" files))))
+      (cond ((and (eq system-type 'windows-nt) rg-w32-unicode)
+             (with-temp-file rg-w32-ripgrep-proxy
+               (insert (format "@echo off\n"))
+               (insert (format "chcp 65001 > null\n"))
+               (insert (format "%s\n" command)))
+             rg-w32-ripgrep-proxy)
+            (t command)))
+    ))
 
 (defun rg-invoke-rg-type-list ()
   "Invokes rg --type-list and return the result."

--- a/rg.el
+++ b/rg.el
@@ -145,13 +145,15 @@ Disabling this setting can break functionality of this package."
   :group 'rg)
 
 (defcustom rg-w32-unicode nil
-  "Enable the workaround for NTEmacs subprocess not supporting Unicode arguments."
+  "Enable Unicode support on Windows.
+A workaround for NTEmacs subprocess not supporting Unicode arguments."
   :type 'boolean
   :group 'rg)
 
 (defcustom rg-w32-ripgrep-proxy
   (expand-file-name "rg-w32-ripgrep-proxy.bat" user-emacs-directory)
-  "An automatically generated temporary batch file used to proxy ripgrep Unicode arguments."
+  "An automatically generated temporary batch file.
+Used to proxy ripgrep Unicode arguments."
   :type 'string
   :group 'rg)
 
@@ -314,6 +316,8 @@ are command line flags to use for the search."
                     (if (rg-is-custom-file-pattern files) "custom" files))))
       (cond ((and (eq system-type 'windows-nt) rg-w32-unicode)
              (with-temp-file rg-w32-ripgrep-proxy
+               (set-buffer-multibyte t)
+               (setq buffer-file-coding-system 'utf-8-dos)
                (insert (format "@echo off\n"))
                (insert (format "chcp 65001 > null\n"))
                (insert (format "%s\n" command)))

--- a/rg.el
+++ b/rg.el
@@ -319,7 +319,7 @@ are command line flags to use for the search."
                (set-buffer-multibyte t)
                (setq buffer-file-coding-system 'utf-8-dos)
                (insert (format "@echo off\n"))
-               (insert (format "chcp 65001 > null\n"))
+               (insert (format "chcp 65001 > nul\n"))
                (insert (format "%s\n" command)))
              rg-w32-ripgrep-proxy)
             (t command)))


### PR DESCRIPTION
A known issue of rg.el is that Unicode search is not supported on windows. 

Some related issues: https://github.com/dajva/rg.el/issues/101 https://github.com/dajva/rg.el/issues/117

The reason is that at the moment NTEmacs limits non-ASCII file arguments to the current codepage, see https://github.com/emacs-mirror/emacs/blob/58a7b99823c5c42161e9acf2abf6c22afd4da4cd/src/w32.c#L1648.

>   Running subprocesses in non-ASCII directories and with non-ASCII
     file arguments is limited to the current codepage (even though
     Emacs is perfectly capable of finding an executable program file
     in a directory whose name cannot be encoded in the current
     codepage).  This is because the command-line arguments are
     encoded _before_ they get to the w32-specific level, and the
     encoding is not known in advance (it doesn't have to be the
     current ANSI codepage), so w32proc.c functions cannot re-encode
     them in UTF-16.  This should be fixed, but will also require
     changes in cmdproxy.  The current limitation is not terribly bad
     anyway, since very few, if any, Windows console programs that are
     likely to be invoked by Emacs support UTF-16 encoded command
     lines.
>   
>   For similar reasons, server.el and emacsclient are also limited
     to the current ANSI codepage for now.
>   
>   Emacs itself can only handle command-line arguments encoded in
     the current codepage.

This patch provides a workaround: Instead of passing Unicode arguments to ripgrep via Emacs, it via a temp .bat script, which was generated whenever `rg-build-command`. This allows rg.el now to search the entire Unicode planes (including rare scripts and Emojis), rather than being restricted to a specific codepage. 

P.s. This feature is disabled by default for keeping old behavior, and can be enabled it via set `rg-w32-unicode` = t.