### PR TITLE
 add buffer local var rg-match-positions to record all match positions

### DIFF
--- a/rg-result.el
+++ b/rg-result.el
@@ -189,6 +189,10 @@ Becomes buffer local in `rg-mode' buffers.")
 (defvar-local rg-hit-count 0
   "Stores number of hits in a search.")
 
+(defvar-local rg-match-positions nil
+  "Stores position of matches in a search.
+Each element is consists by (match-beginning-marker . match-string-length).")
+
 (defvar-local rg-recompile nil
   "Is `recompile' in progress or `compile-start'.")
 
@@ -469,8 +473,11 @@ This function is called from `compilation-filter-hook'."
           (replace-match (propertize (match-string 1)
                                      'face nil 'font-lock-face 'rg-match-face)
                          t t)
+          (push (cons (copy-marker (match-beginning 0))
+                      (length (match-string 0)))
+                rg-match-positions)
           (cl-incf rg-hit-count))
-
+        (setq rg-match-positions (nreverse rg-match-positions))
         (rg-format-line-and-column-numbers beg end)
 
         ;; Delete all remaining escape sequences


### PR DESCRIPTION
with the new var, user can replace  matches  very easily, how about this ? @dajva 