### PR TITLE
Truncated search pattern in header

### DIFF
--- a/rg-result.el
+++ b/rg-result.el
@@ -795,6 +795,10 @@ previous file with grouped matches."
                 (push (cons filepath nextfile) elements))
               (nreverse elements))))))
 
+(defun rg-cur-search-pattern ()
+  "Get the current search pattern."
+  (rg-search-pattern rg-cur-search))
+
 (provide 'rg-result)
 
 ;; Local Variables:

--- a/test/rg-header.el-test.el
+++ b/test/rg-header.el-test.el
@@ -1,0 +1,99 @@
+(require 'cl-lib)
+(require 'mule-util)
+
+(defvar rg-unit/long-search-pattern "everything everywhere all at once")
+
+;;; Mocks.
+
+(cl-defmacro rg-unit/mock-truncation-predicate ((&key max predicate) &rest body)
+  "Execute BODY with truncation predicate mocked by PREDICATE.
+
+MAX is the value `rg-header-max-search-string-length' will be set to."
+  (declare (indent defun))
+  `(cl-letf* ((rg-header-max-search-string-length ,max)
+              ((symbol-function 'rg-header-truncates-p) #',predicate))
+     ,@body))
+
+(cl-defmacro rg-unit/mock-rg-cur-search-pattern ((&key do-return) &rest body)
+  "Execute BODY with `rg-cur-search-pattern' mocked.
+
+Instead DO-RETURN will be returned when the function is called."
+  (declare (indent defun))
+
+  `(cl-letf* (((symbol-function 'rg-cur-search-pattern) (lambda (&rest _) ,do-return)))
+     ,@body))
+
+;;; Tests.
+
+(ert-deftest rg-unit/header-truncation-predicate ()
+  "Test `rg-header-truncates-p'."
+
+  ;; Not set.
+  (let ((rg-header-max-search-string-length nil))
+
+    (should-not (rg-header-truncates-p rg-unit/long-search-pattern)))
+
+  ;; Erroneous value.
+  (let ((rg-header-max-search-string-length 'none))
+
+    (should-not (rg-header-truncates-p rg-unit/long-search-pattern)))
+
+  ;; The length of the string passed.
+  (let ((rg-header-max-search-string-length (length rg-unit/long-search-pattern)))
+
+    (should-not (rg-header-truncates-p rg-unit/long-search-pattern)))
+
+  ;; One below string length.
+  (let ((rg-header-max-search-string-length (1- (length rg-unit/long-search-pattern))))
+
+    (should (rg-header-truncates-p rg-unit/long-search-pattern)))
+
+  ;; At 0.
+  (let ((rg-header-max-search-string-length 0))
+
+    (should (rg-header-truncates-p rg-unit/long-search-pattern)))
+
+  ;; Below 0.
+  (let ((rg-header-max-search-string-length -1))
+
+    (should (rg-header-truncates-p rg-unit/long-search-pattern))))
+
+
+(ert-deftest rg-unit/search-pattern-truncation-in-header ()
+  "Tests `rg-header-truncate-search-pattern'."
+  ;; When predicate is true.
+  (rg-unit/mock-truncation-predicate (:max 11 :predicate always)
+    (should (string=
+             (concat "everything" (truncate-string-ellipsis))
+             (rg-header-truncate-search-pattern rg-unit/long-search-pattern))))
+
+  (rg-unit/mock-truncation-predicate (:max 5 :predicate always)
+    (should (string=
+             "ever…"
+             (rg-header-truncate-search-pattern rg-unit/long-search-pattern))))
+
+  (rg-unit/mock-truncation-predicate (:max (length rg-unit/long-search-pattern) :predicate always)
+    (should (string=
+             "everything everywhere all at once"
+             (rg-header-truncate-search-pattern rg-unit/long-search-pattern))))
+
+  ;; When predicate is false.
+  (rg-unit/mock-truncation-predicate (:max 11 :predicate ignore)
+    (should (string=
+             "everything everywhere all at once"
+             (rg-header-truncate-search-pattern rg-unit/long-search-pattern))))
+
+  (rg-unit/mock-truncation-predicate (:predicate ignore)
+    (should (string=
+             "everything everywhere all at once"
+             (rg-header-truncate-search-pattern rg-unit/long-search-pattern)))))
+
+(ert-deftest rg-unit/search-help-for-header ()
+  "Tests `rg-header-search-help'."
+  (rg-unit/mock-rg-cur-search-pattern (:do-return "this is the full string")
+
+    (rg-unit/mock-truncation-predicate (:predicate always)
+      (should (string= "Change search string: this is the full string" (rg-header-search-help))))
+
+    (rg-unit/mock-truncation-predicate (:predicate ignore)
+      (should (string= "Change search string" (rg-header-search-help))))))


### PR DESCRIPTION
This is an attempt to tackle #164.

It's a bit awkward since it means we need to use a function for the `help-echo` prop that needs to access `rg-cur-search` to access the full search pattern.

Maybe you have a better idea.