### PR TITLE
Fix configuration.org

### DIFF
--- a/docs/configuration.org
+++ b/docs/configuration.org
@@ -204,7 +204,7 @@
       (let ((p (project-current)))
         (if p
             (format "rg %s" (abbreviate-file-name (cdr p)))
-          "rg"))))
+          "rg")))
   #+END_SRC
   :END:
 


### PR DESCRIPTION
Keep the parentheses of func `my-rg-buffer-name`  balanced