### PR TITLE
Fix wgrep footer marking excluding last result from edits

### DIFF
--- a/wgrep-rg.el
+++ b/wgrep-rg.el
@@ -93,10 +93,9 @@ the content."
                                        '(read-only t wgrep-header t))
                   nil)))))
         (goto-char (point-max))
-        (re-search-backward "^rg finished .*$" nil t)
-        ;; Move to the start of the line after the last result, and
-        ;; mark everything from that line forward as wgrep-footer.
-        (when (zerop (forward-line -1))
+        (when (re-search-backward "^rg finished .*$" nil t)
+          ;; Mark the "rg finished" line and everything after it as footer.
+          (beginning-of-line)
           (add-text-properties (point) (point-max)
                                '(read-only t wgrep-footer t))))))
 


### PR DESCRIPTION
The previous code used (forward-line -1) after finding the 'rg finished' line, which moved point to the last result line and marked it as read-only footer. This caused wgrep to skip the last match during search-replace operations.

Fix by using (beginning-of-line) on the 'rg finished' line itself, so only that line and anything after it is marked as footer.